### PR TITLE
Allow user to specify path to bolt binary

### DIFF
--- a/tasks/init.json
+++ b/tasks/init.json
@@ -16,6 +16,10 @@
     "debug": {
       "type": "Optional[Boolean]",
       "description": "Set to true to enable debug output"
+    },
+    "bolt_path": {
+      "type": "Optional[String]",
+      "description": "The full path to the bolt binary"
     }
   },
   "input_method": "stdin",

--- a/tasks/init.rb
+++ b/tasks/init.rb
@@ -11,8 +11,15 @@ require 'open3'
 $params = JSON.parse(STDIN.read)
 
 def main
+
+  if $params['bolt_path'].nil?
+    $bolt_path = 'bolt'
+  else
+    $bolt_path = $params['bolt_path']
+  end
+
   cmd = Array.new
-  cmd << 'bolt' << 'plan' << 'run'
+  cmd << $bolt_path << 'plan' << 'run'
   cmd << $params['plan']
   cmd << '--params' << $params['params'].to_json
   cmd << '--format' << 'json'


### PR DESCRIPTION
The path can be specified with the 'bolt_path' parameter.
If omitted then just 'bolt' will be used for the full path.