### PR TITLE
Adding env parameter to pass environment variables to bolt when invoked

### DIFF
--- a/tasks/init.json
+++ b/tasks/init.json
@@ -13,6 +13,10 @@
       "type": "Hash",
       "description": "Hash of Bolt arguments to pass, e.g.: {modulepath=>/expl/path, ssl-verify=>false}"
     },
+    "env": {
+      "type": "Optional[Hash]",
+      "description": "Hash of environment variables to pass to the bolt command"
+    },
     "debug": {
       "type": "Optional[Boolean]",
       "description": "Set to true to enable debug output"

--- a/tasks/init.rb
+++ b/tasks/init.rb
@@ -28,15 +28,25 @@ def main
     end
   end
 
-  if run_command(*cmd).success?
+  unless $params.has_key? 'env'
+    $params['env'] = {}
+  end
+
+  unless $params['env'].has_key? 'HOME'
+    $params['env'] = {
+      'HOME' => '/root',
+    }
+  end
+
+  if run_command($params['env'], *cmd).success?
     exit 0
   else
     exit 1
   end
 end
 
-def run_command(*command)
-  output, status = Open3.capture2e(*command)
+def run_command(env, *command)
+  output, status = Open3.capture2e(env, *command)
   STDOUT.puts output
   status
 end


### PR DESCRIPTION
This allows the user to pass environment variables to bolt.