### PR TITLE
Make the arguments task parameter optional

### DIFF
--- a/tasks/init.json
+++ b/tasks/init.json
@@ -11,8 +11,7 @@
     },
     "arguments": {
       "type": "Optional[Hash]",
-      "description": "Hash of Bolt arguments to pass, e.g.: {modulepath=>/expl/path, ssl-verify=>false}",
-      "default": { }
+      "description": "Hash of Bolt arguments to pass, e.g.: {modulepath=>/expl/path, ssl-verify=>false}"
     },
     "debug": {
       "type": "Optional[Boolean]",

--- a/tasks/init.json
+++ b/tasks/init.json
@@ -10,7 +10,7 @@
       "description": "Parameters to give to the plan"
     },
     "arguments": {
-      "type": "Hash",
+      "type": "Optional[Hash]",
       "description": "Hash of Bolt arguments to pass, e.g.: {modulepath=>/expl/path, ssl-verify=>false}",
       "default": { }
     },


### PR DESCRIPTION
### Changes

I'm making the `arguments` param an Optional Hash and I'm also removing the default value `{ }` so the PE console doesn't render the field on the task page.